### PR TITLE
Remove pythia dep; migrate CloudKeyManager to BrainkeyClient (foundation-android)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,10 +34,9 @@
 buildscript {
     ext.versions = [
             // Virgil
-            virgilSdk       : '7.4.0',
-            virgilCrypto    : '0.17.2',
-            pythia          : '0.4.0', // With virgilCrypto 0.17.2
-            ratchet         : '0.3.0', // With virgilCrypto 0.17.2
+            virgilSdk       : '7.5.0',
+            virgilCrypto    : '0.19.0-rc.11',
+            ratchet         : '0.4.0',
 
             // Kotlin
             kotlin          : '1.9.24',
@@ -97,9 +96,6 @@ allprojects {
         }
         maven {
             url "https://jitpack.io"
-        }
-        maven {
-            url "https://jcenter.bintray.com/"
         }
         maven {
             url "https://central.sonatype.com/repository/maven-snapshots/"

--- a/ethree-common/build.gradle
+++ b/ethree-common/build.gradle
@@ -58,9 +58,8 @@ dependencies {
     api "com.virgilsecurity.sdk:sdk-android:$versions.virgilSdk"
     api "com.virgilsecurity.sdk:crypto-android:$versions.virgilSdk"
 
-    // Virgil Pythia
-    api "com.virgilsecurity:pythia-android:$versions.pythia"
-    api "com.virgilsecurity.crypto:pythia-android:$versions.virgilCrypto"
+    // Virgil Crypto Foundation
+    api "com.virgilsecurity.crypto:foundation-android:$versions.virgilCrypto"
 
     // Virgil Ratchet
     api "com.virgilsecurity:ratchet-android:$versions.ratchet"

--- a/ethree-common/src/androidTest/java/com/virgilsecurity/android/common/worker/BackupTests.kt
+++ b/ethree-common/src/androidTest/java/com/virgilsecurity/android/common/worker/BackupTests.kt
@@ -43,11 +43,8 @@ import com.virgilsecurity.keyknox.KeyknoxManager
 import com.virgilsecurity.keyknox.client.KeyknoxClient
 import com.virgilsecurity.keyknox.cloud.CloudKeyStorage
 import com.virgilsecurity.keyknox.crypto.KeyknoxCrypto
+import com.virgilsecurity.android.common.storage.cloud.BrainkeyHttpClient
 import com.virgilsecurity.keyknox.storage.SyncKeyStorage
-import com.virgilsecurity.pythia.brainkey.BrainKey
-import com.virgilsecurity.pythia.brainkey.BrainKeyContext
-import com.virgilsecurity.pythia.client.VirgilPythiaClient
-import com.virgilsecurity.pythia.crypto.VirgilPythiaCrypto
 import com.virgilsecurity.sdk.crypto.VirgilCrypto
 import com.virgilsecurity.sdk.jwt.accessProviders.CachingJwtProvider
 import com.virgilsecurity.sdk.storage.DefaultKeyStorage
@@ -91,12 +88,8 @@ class BackupTests {
         val tokenProvider = CachingJwtProvider(CachingJwtProvider.RenewJwtCallback {
             TestUtils.generateToken(identity)
         })
-        val brainKeyContext = BrainKeyContext.Builder()
-                .setAccessTokenProvider(tokenProvider)
-                .setPythiaClient(VirgilPythiaClient(TestConfig.virgilServiceAddress))
-                .setPythiaCrypto(VirgilPythiaCrypto())
-                .build()
-        val keyPair = BrainKey(brainKeyContext).generateKeyPair(passwordBrainKey)
+        val keyPair = BrainkeyHttpClient(tokenProvider, TestConfig.virgilServiceAddress)
+                .deriveKeyPair(passwordBrainKey, VirgilCrypto())
 
         val syncKeyStorage = SyncKeyStorage(
             identity,

--- a/ethree-common/src/main/java/com/virgilsecurity/android/common/model/Group.kt
+++ b/ethree-common/src/main/java/com/virgilsecurity/android/common/model/Group.kt
@@ -195,7 +195,7 @@ class Group internal constructor(
             } else {
                 val sessionId = encrypted.sessionId.toData()
 
-                val tempGroup = this.groupManager.retrieve(sessionId, messageEpoch)
+                val tempGroup = this.groupManager.retrieve(sessionId, messageEpoch.toLong())
                                 ?: throw GroupException(
                                     GroupException.Description.MISSING_CACHED_GROUP
                                 )

--- a/ethree-common/src/main/java/com/virgilsecurity/android/common/storage/cloud/BrainkeyHttpClient.kt
+++ b/ethree-common/src/main/java/com/virgilsecurity/android/common/storage/cloud/BrainkeyHttpClient.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2015-2020, Virgil Security, Inc.
+ *
+ * Lead Maintainer: Virgil Security Inc. <support@virgilsecurity.com>
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     (1) Redistributions of source code must retain the above copyright notice, this
+ *     list of conditions and the following disclaimer.
+ *
+ *     (2) Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ *     (3) Neither the name of virgil nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.virgilsecurity.android.common.storage.cloud
+
+import com.google.gson.JsonObject
+import com.virgilsecurity.android.common.build.VirgilInfo
+import com.virgilsecurity.android.common.util.Const
+import com.virgilsecurity.crypto.foundation.BrainkeyClient
+import com.virgilsecurity.keyknox.client.HttpClient
+import com.virgilsecurity.keyknox.client.Method
+import com.virgilsecurity.keyknox.utils.Serializer
+import com.virgilsecurity.sdk.crypto.KeyPairType
+import com.virgilsecurity.sdk.crypto.VirgilCrypto
+import com.virgilsecurity.sdk.crypto.VirgilKeyPair
+import com.virgilsecurity.sdk.jwt.TokenContext
+import com.virgilsecurity.sdk.jwt.contract.AccessTokenProvider
+import com.virgilsecurity.sdk.utils.ConvertionUtils
+import java.net.URL
+
+/**
+ * HTTP client for the Virgil brainkey /pythia/v1/brainkey endpoint.
+ * Provides key-pair derivation from a password via the OPRF brainkey protocol.
+ * ed25519 is required because KeyknoxCrypto.encrypt signs data with the private key
+ * (curve25519/X25519 is key-agreement only and cannot sign).
+ */
+class BrainkeyHttpClient(
+    tokenProvider: AccessTokenProvider,
+    private val baseUrl: String = Const.VIRGIL_BASE_URL
+) {
+    private val httpClient = HttpClient(tokenProvider, Const.ETHREE_NAME, VirgilInfo.VERSION)
+
+    fun harden(blindedPoint: ByteArray): ByteArray {
+        val url = URL("$baseUrl/pythia/v1/brainkey")
+        val body = mapOf("blinded_password" to ConvertionUtils.toBase64String(blindedPoint))
+        val response = httpClient.send(url, Method.POST, TOKEN_CONTEXT, body, null)
+        val json = Serializer.gson.fromJson(response.body, JsonObject::class.java)
+        return ConvertionUtils.base64ToBytes(json.get("seed").asString)
+    }
+
+    fun deriveKeyPair(password: String, crypto: VirgilCrypto): VirgilKeyPair {
+        BrainkeyClient().use { brainkeyClient ->
+            brainkeyClient.setupDefaults()
+            val blindResult = brainkeyClient.blind(password.toByteArray())
+            val hardenedPoint = harden(blindResult.blindedPoint)
+            val seed = brainkeyClient.deblind(
+                password.toByteArray(),
+                hardenedPoint,
+                blindResult.deblindFactor,
+                KEY_NAME
+            )
+            return crypto.generateKeyPair(KeyPairType.ED25519, seed)
+        }
+    }
+
+    companion object {
+        private val TOKEN_CONTEXT = TokenContext("brainkey", "harden")
+        private val KEY_NAME = "e3kit-backup".toByteArray()
+    }
+}

--- a/ethree-common/src/main/java/com/virgilsecurity/android/common/storage/cloud/CloudKeyManager.kt
+++ b/ethree-common/src/main/java/com/virgilsecurity/android/common/storage/cloud/CloudKeyManager.kt
@@ -39,20 +39,14 @@ import com.virgilsecurity.android.common.util.Const
 import com.virgilsecurity.android.common.util.Const.VIRGIL_BASE_URL
 import com.virgilsecurity.keyknox.KeyknoxManager
 import com.virgilsecurity.keyknox.client.*
-import com.virgilsecurity.keyknox.cloud.CloudEntrySerializer
 import com.virgilsecurity.keyknox.cloud.CloudKeyStorage
 import com.virgilsecurity.keyknox.exception.*
-import com.virgilsecurity.keyknox.model.CloudEntries
 import com.virgilsecurity.keyknox.model.CloudEntry
 import com.virgilsecurity.keyknox.utils.Serializer
-import com.virgilsecurity.pythia.brainkey.BrainKey
-import com.virgilsecurity.pythia.brainkey.BrainKeyContext
-import com.virgilsecurity.pythia.client.VirgilPythiaClient
-import com.virgilsecurity.pythia.crypto.VirgilPythiaCrypto
 import com.virgilsecurity.sdk.crypto.VirgilCrypto
+import com.virgilsecurity.sdk.crypto.VirgilKeyPair
 import com.virgilsecurity.sdk.crypto.VirgilPrivateKey
 import com.virgilsecurity.sdk.jwt.contract.AccessTokenProvider
-import com.virgilsecurity.sdk.storage.JsonKeyEntry
 import com.virgilsecurity.sdk.utils.ConvertionUtils
 import java.net.URL
 import java.util.*
@@ -68,24 +62,17 @@ internal class CloudKeyManager internal constructor(
 ) {
 
     private val keyknoxManager: KeyknoxManager
-    private val brainKey: BrainKey
+    private val brainkeyHttpClient: BrainkeyHttpClient
 
     init {
         val httpClient = HttpClient(tokenProvider, Const.ETHREE_NAME, VirgilInfo.VERSION)
         val keyknoxClient = KeyknoxClient(httpClient, URL(baseUrl))
         this.keyknoxManager = KeyknoxManager(keyknoxClient)
-
-        // TODO change VirgilPythiaClient to have tokenProvider inside
-        val pythiaClient = VirgilPythiaClient(baseUrl, Const.ETHREE_NAME, Const.ETHREE_NAME,
-                VirgilInfo.VERSION)
-        val brainKeyContext = BrainKeyContext.Builder()
-                .setAccessTokenProvider(tokenProvider)
-                .setPythiaClient(pythiaClient)
-                .setPythiaCrypto(VirgilPythiaCrypto())
-                .build()
-
-        this.brainKey = BrainKey(brainKeyContext)
+        this.brainkeyHttpClient = BrainkeyHttpClient(tokenProvider, baseUrl)
     }
+
+    private fun deriveKeyPair(password: String): VirgilKeyPair =
+        brainkeyHttpClient.deriveKeyPair(password, crypto)
 
     internal fun exists(password: String) = setupCloudKeyStorage(password).exists(identity)
 
@@ -96,7 +83,7 @@ internal class CloudKeyManager internal constructor(
             setupCloudKeyStorage(password).store(this.identity, exportedIdentityKey)
         } else {
             // Store key in keyknox v2
-            val brainKeyPair = this.brainKey.generateKeyPair(password)
+            val brainKeyPair = deriveKeyPair(password)
             val pullParams = KeyknoxPullParams(this.identity, "e3kit", "backup", keyName)
             val keyknoxValue = this.keyknoxManager.pullValue(pullParams, listOf(brainKeyPair.publicKey), brainKeyPair.privateKey)
 
@@ -117,15 +104,14 @@ internal class CloudKeyManager internal constructor(
             return setupCloudKeyStorage(password).retrieve(keyName ?: this.identity)
         } else {
             // Retrieve key from keyknox v2
-            val brainKeyPair = this.brainKey.generateKeyPair(password)
+            val brainKeyPair = deriveKeyPair(password)
             val pullParams = KeyknoxPullParams(this.identity, "e3kit", "backup", keyName)
             val keyknoxValue = try {
                 this.keyknoxManager.pullValue(pullParams, listOf(brainKeyPair.publicKey), brainKeyPair.privateKey)
             } catch (e: DecryptionFailedException) {
                 throw EThreeException(EThreeException.Description.WRONG_PASSWORD)
             }
-            val entry = Serializer.gson.fromJson<CloudEntry>(ConvertionUtils.toString(keyknoxValue.value), CloudEntry::class.java)
-            return entry
+            return Serializer.gson.fromJson(ConvertionUtils.toString(keyknoxValue.value), CloudEntry::class.java)
         }
     }
 
@@ -146,18 +132,15 @@ internal class CloudKeyManager internal constructor(
         if (keyName == null) {
             // Change password for key from keyknox v1
             val cloudKeyStorage = setupCloudKeyStorage(oldPassword)
-
-            val brainKeyPair = this.brainKey.generateKeyPair(newPassword)
-
+            val brainKeyPair = deriveKeyPair(newPassword)
             try {
-                cloudKeyStorage.updateRecipients(listOf(brainKeyPair.publicKey),
-                        brainKeyPair.privateKey)
+                cloudKeyStorage.updateRecipients(listOf(brainKeyPair.publicKey), brainKeyPair.privateKey)
             } catch (e: KeyknoxCryptoException) {
                 throw EThreeException(EThreeException.Description.WRONG_PASSWORD)
             }
         } else {
             // Change password for key from keyknox v2
-            val brainKeyPair = this.brainKey.generateKeyPair(oldPassword)
+            val brainKeyPair = deriveKeyPair(oldPassword)
             val pullParams = KeyknoxPullParams(this.identity, "e3kit", "backup", keyName)
             val keyknoxValue = try {
                 this.keyknoxManager.pullValue(pullParams, listOf(brainKeyPair.publicKey), brainKeyPair.privateKey)
@@ -169,18 +152,18 @@ internal class CloudKeyManager internal constructor(
                 return
             }
 
-            val newBrainKeyPair = this.brainKey.generateKeyPair(newPassword)
+            val newBrainKeyPair = deriveKeyPair(newPassword)
             val params = KeyknoxPushParams(listOf(this.identity), "e3kit", "backup", keyName)
             this.keyknoxManager.pushValue(params, keyknoxValue.value, keyknoxValue.keyknoxHash, listOf(newBrainKeyPair.publicKey), newBrainKeyPair.privateKey)
         }
     }
 
     /**
-     * Initializes [SyncKeyStorage] with default settings, [tokenProvider] and provided
-     * [password] after that returns initialized [SyncKeyStorage] object.
+     * Initializes [CloudKeyStorage] with default settings, [tokenProvider] and provided
+     * [password] after that returns initialized [CloudKeyStorage] object.
      */
     internal fun setupCloudKeyStorage(password: String): CloudKeyStorage {
-        val brainKeyPair = this.brainKey.generateKeyPair(password)
+        val brainKeyPair = deriveKeyPair(password)
 
         val cloudKeyStorage = CloudKeyStorage(this.keyknoxManager, listOf(brainKeyPair.publicKey),
                 brainKeyPair.privateKey)

--- a/tests/src/androidTest/java/com/virgilsecurity/android/ethree/interaction/async/EThreeBackupTest.kt
+++ b/tests/src/androidTest/java/com/virgilsecurity/android/ethree/interaction/async/EThreeBackupTest.kt
@@ -47,11 +47,8 @@ import com.virgilsecurity.keyknox.KeyknoxManager
 import com.virgilsecurity.keyknox.client.KeyknoxClient
 import com.virgilsecurity.keyknox.cloud.CloudKeyStorage
 import com.virgilsecurity.keyknox.crypto.KeyknoxCrypto
+import com.virgilsecurity.android.common.storage.cloud.BrainkeyHttpClient
 import com.virgilsecurity.keyknox.storage.SyncKeyStorage
-import com.virgilsecurity.pythia.brainkey.BrainKey
-import com.virgilsecurity.pythia.brainkey.BrainKeyContext
-import com.virgilsecurity.pythia.client.VirgilPythiaClient
-import com.virgilsecurity.pythia.crypto.VirgilPythiaCrypto
 import com.virgilsecurity.sdk.common.TimeSpan
 import com.virgilsecurity.sdk.crypto.VirgilAccessTokenSigner
 import com.virgilsecurity.sdk.jwt.JwtGenerator
@@ -156,12 +153,8 @@ class EThreeBackupTest {
         val tokenProvider = CachingJwtProvider(CachingJwtProvider.RenewJwtCallback {
             jwtGenerator.generateToken(identity)
         })
-        val brainKeyContext = BrainKeyContext.Builder()
-                .setAccessTokenProvider(tokenProvider)
-                .setPythiaClient(VirgilPythiaClient(virgilServiceAddress))
-                .setPythiaCrypto(VirgilPythiaCrypto())
-                .build()
-        val keyPair = BrainKey(brainKeyContext).generateKeyPair(passwordBrainKey)
+        val keyPair = BrainkeyHttpClient(tokenProvider, virgilServiceAddress)
+                .deriveKeyPair(passwordBrainKey, TestConfig.virgilCrypto)
 
         val syncKeyStorage = SyncKeyStorage(
             identity,

--- a/tests/src/androidTest/java/com/virgilsecurity/android/ethree/interaction/async/EThreeBackupWithKeyNameTest.kt
+++ b/tests/src/androidTest/java/com/virgilsecurity/android/ethree/interaction/async/EThreeBackupWithKeyNameTest.kt
@@ -46,11 +46,8 @@ import com.virgilsecurity.keyknox.KeyknoxManager
 import com.virgilsecurity.keyknox.client.KeyknoxClient
 import com.virgilsecurity.keyknox.cloud.CloudKeyStorage
 import com.virgilsecurity.keyknox.crypto.KeyknoxCrypto
+import com.virgilsecurity.android.common.storage.cloud.BrainkeyHttpClient
 import com.virgilsecurity.keyknox.storage.SyncKeyStorage
-import com.virgilsecurity.pythia.brainkey.BrainKey
-import com.virgilsecurity.pythia.brainkey.BrainKeyContext
-import com.virgilsecurity.pythia.client.VirgilPythiaClient
-import com.virgilsecurity.pythia.crypto.VirgilPythiaCrypto
 import com.virgilsecurity.sdk.common.TimeSpan
 import com.virgilsecurity.sdk.crypto.VirgilAccessTokenSigner
 import com.virgilsecurity.sdk.jwt.JwtGenerator
@@ -112,12 +109,8 @@ class EThreeBackupWithKeyNameTest {
         val tokenProvider = CachingJwtProvider(CachingJwtProvider.RenewJwtCallback {
             jwtGenerator.generateToken(identity)
         })
-        val brainKeyContext = BrainKeyContext.Builder()
-                .setAccessTokenProvider(tokenProvider)
-                .setPythiaClient(VirgilPythiaClient(virgilServiceAddress))
-                .setPythiaCrypto(VirgilPythiaCrypto())
-                .build()
-        val keyPair = BrainKey(brainKeyContext).generateKeyPair(passwordBrainKey)
+        val keyPair = BrainkeyHttpClient(tokenProvider, virgilServiceAddress)
+                .deriveKeyPair(passwordBrainKey, TestConfig.virgilCrypto)
 
         val syncKeyStorage = SyncKeyStorage(
             identity,

--- a/tests/src/androidTest/java/com/virgilsecurity/android/ethree/interaction/sync/EThreeSyncPositive.kt
+++ b/tests/src/androidTest/java/com/virgilsecurity/android/ethree/interaction/sync/EThreeSyncPositive.kt
@@ -40,11 +40,8 @@ import com.virgilsecurity.keyknox.KeyknoxManager
 import com.virgilsecurity.keyknox.client.KeyknoxClient
 import com.virgilsecurity.keyknox.cloud.CloudKeyStorage
 import com.virgilsecurity.keyknox.crypto.KeyknoxCrypto
+import com.virgilsecurity.android.common.storage.cloud.BrainkeyHttpClient
 import com.virgilsecurity.keyknox.storage.SyncKeyStorage
-import com.virgilsecurity.pythia.brainkey.BrainKey
-import com.virgilsecurity.pythia.brainkey.BrainKeyContext
-import com.virgilsecurity.pythia.client.VirgilPythiaClient
-import com.virgilsecurity.pythia.crypto.VirgilPythiaCrypto
 import com.virgilsecurity.sdk.cards.CardManager
 import com.virgilsecurity.sdk.cards.model.RawSignedModel
 import com.virgilsecurity.sdk.cards.validation.VirgilCardVerifier
@@ -125,12 +122,8 @@ class EThreeSyncPositive {
         val tokenProvider = CachingJwtProvider(CachingJwtProvider.RenewJwtCallback {
             jwtGenerator.generateToken(identity)
         })
-        val brainKeyContext = BrainKeyContext.Builder()
-                .setAccessTokenProvider(tokenProvider)
-                .setPythiaClient(VirgilPythiaClient(TestConfig.virgilServiceAddress))
-                .setPythiaCrypto(VirgilPythiaCrypto())
-                .build()
-        val keyPair = BrainKey(brainKeyContext).generateKeyPair(passwordBrainKey)
+        val keyPair = BrainkeyHttpClient(tokenProvider, TestConfig.virgilServiceAddress)
+                .deriveKeyPair(passwordBrainKey, crypto)
 
         val syncKeyStorage = SyncKeyStorage(
             identity,


### PR DESCRIPTION
Remove pythia-android dependencies; add foundation-android 0.19.0-rc.11; bump SDK 7.5.0, ratchet 0.4.0; new BrainkeyHttpClient using OPRF protocol via /pythia/v1/brainkey endpoint; CloudKeyManager uses BrainkeyClient.blind/deblind instead of Pythia SDK