### PR TITLE
Migrate cloud key backup to brainkey v3 OPRF with DLEQ proof (v3.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Virgil E3Kit Android
 
-[![Build Status](https://travis-ci.com/VirgilSecurity/virgil-e3kit-kotlin.svg?branch=master)](https://travis-ci.com/VirgilSecurity/virgil-e3kit-kotlin)
+[![Build Status](https://github.com/VirgilSecurity/virgil-e3kit-kotlin/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/VirgilSecurity/virgil-e3kit-kotlin/actions/workflows/build-and-test.yml)
 [![GitHub license](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](https://github.com/VirgilSecurity/virgil/blob/master/LICENSE)
 [![API Reference](https://img.shields.io/badge/API%20reference-e3kit--kotlin-green)](https://virgilsecurity.github.io/virgil-e3kit-kotlin/)
 
@@ -28,7 +28,7 @@
 - Access to encrypted data from multiple user devices
 - Perfect forward secrecy with the Double Ratchet algorithm
 - Encryption for unregistered users
-- Post-quantum algorithms support: [Round5](https://round5.org/) (encryption), [Falcon](https://falcon-sign.info/) (signature)
+- Post-quantum algorithms support: ML-KEM-768 (encryption), [Falcon](https://falcon-sign.info/) (signature)
 
 ## Installation
 
@@ -55,6 +55,20 @@ You can find the code samples for Java and Kotlin here:
 | [`Android Kotlin Nexmo`](./samples/android-kotlin-nexmo) | 
 
 You can run the samples to see how to initialize the SDK, register users and encrypt messages using E3Kit.
+
+## Upgrading from v2.x
+
+**Cloud key backup (password-protected private key) is not compatible between v2.x and v3.0.**
+
+v3.0 switches the backup key derivation from the legacy Pythia protocol to the OPRF brainkey v3 protocol with DLEQ proof verification. These protocols produce different encryption keys, so a backup created by v2.x cannot be restored by v3.0 and vice versa.
+
+**Migration steps for your users:**
+
+1. Upgrade the SDK to v3.0.
+2. After login, call `backupPrivateKey(password)` to create a new backup under the new protocol.
+3. The old v2.x backup entry on Keyknox will remain but is no longer accessible — it can be cleaned up by calling `resetPrivateKeyBackup()` before step 2.
+
+Users who cannot re-backup (e.g. lost access to their device) must re-register with a new key pair.
 
 ## License
 

--- a/build.gradle
+++ b/build.gradle
@@ -151,7 +151,7 @@ def getGradleOrSystemProperty(String name, Project project) {
 final String BASE_VIRGIL_PACKAGE = 'com.virgilsecurity'
 
 // Packages versions
-final String SDK_VERSION = '2.2.0'
+final String SDK_VERSION = '3.0.0'
 
 final Map<String, String> namespaces = [
         'ethree-common'   : 'com.virgilsecurity.android.common',

--- a/ethree-common/src/main/java/com/virgilsecurity/android/common/storage/cloud/BrainkeyHttpClient.kt
+++ b/ethree-common/src/main/java/com/virgilsecurity/android/common/storage/cloud/BrainkeyHttpClient.kt
@@ -35,6 +35,7 @@ package com.virgilsecurity.android.common.storage.cloud
 
 import com.google.gson.JsonObject
 import com.virgilsecurity.android.common.build.VirgilInfo
+import com.virgilsecurity.android.common.exception.EThreeException
 import com.virgilsecurity.android.common.util.Const
 import com.virgilsecurity.crypto.foundation.BrainkeyClient
 import com.virgilsecurity.keyknox.client.HttpClient
@@ -48,34 +49,48 @@ import com.virgilsecurity.sdk.jwt.contract.AccessTokenProvider
 import com.virgilsecurity.sdk.utils.ConvertionUtils
 import java.net.URL
 
-/**
- * HTTP client for the Virgil brainkey /pythia/v1/brainkey endpoint.
- * Provides key-pair derivation from a password via the OPRF brainkey protocol.
- * ed25519 is required because KeyknoxCrypto.encrypt signs data with the private key
- * (curve25519/X25519 is key-agreement only and cannot sign).
- */
 class BrainkeyHttpClient(
     tokenProvider: AccessTokenProvider,
     private val baseUrl: String = Const.VIRGIL_BASE_URL
 ) {
     private val httpClient = HttpClient(tokenProvider, Const.ETHREE_NAME, VirgilInfo.VERSION)
 
-    fun harden(blindedPoint: ByteArray): ByteArray {
-        val url = URL("$baseUrl/pythia/v1/brainkey")
-        val body = mapOf("blinded_password" to ConvertionUtils.toBase64String(blindedPoint))
+    private data class HardenResponse(
+        val hardenedPoint: ByteArray,
+        val serverPublicKey: ByteArray,
+        val proofValueC: ByteArray,
+        val proofValueS: ByteArray
+    )
+
+    private fun harden(blindedPoint: ByteArray): HardenResponse {
+        val url = URL("$baseUrl/brainkey/v3/harden")
+        val body = mapOf("blinded_point" to ConvertionUtils.toBase64String(blindedPoint))
         val response = httpClient.send(url, Method.POST, TOKEN_CONTEXT, body, null)
         val json = Serializer.gson.fromJson(response.body, JsonObject::class.java)
-        return ConvertionUtils.base64ToBytes(json.get("seed").asString)
+        return HardenResponse(
+            hardenedPoint = ConvertionUtils.base64ToBytes(json.get("hardened_point").asString),
+            serverPublicKey = ConvertionUtils.base64ToBytes(json.get("server_public_key").asString),
+            proofValueC = ConvertionUtils.base64ToBytes(json.get("proof_value_c").asString),
+            proofValueS = ConvertionUtils.base64ToBytes(json.get("proof_value_s").asString)
+        )
     }
 
     fun deriveKeyPair(password: String, crypto: VirgilCrypto): VirgilKeyPair {
         BrainkeyClient().use { brainkeyClient ->
             brainkeyClient.setupDefaults()
             val blindResult = brainkeyClient.blind(password.toByteArray())
-            val hardenedPoint = harden(blindResult.blindedPoint)
+            val resp = harden(blindResult.blindedPoint)
+            val valid = brainkeyClient.verify(
+                blindResult.blindedPoint,
+                resp.hardenedPoint,
+                resp.serverPublicKey,
+                resp.proofValueC,
+                resp.proofValueS
+            )
+            if (!valid) throw EThreeException(EThreeException.Description.WRONG_PASSWORD)
             val seed = brainkeyClient.deblind(
                 password.toByteArray(),
-                hardenedPoint,
+                resp.hardenedPoint,
                 blindResult.deblindFactor,
                 KEY_NAME
             )


### PR DESCRIPTION
## Summary

- Switches `BrainkeyHttpClient` from the legacy `/pythia/v1/brainkey` (Pythia protocol) to `/brainkey/v3/harden` (OPRF + DLEQ proof verification)
- `deriveKeyPair()` now calls `BrainkeyClient.verify()` before `deblind()`; throws `WRONG_PASSWORD` if the DLEQ proof fails
- Request field renamed `blinded_password` → `blinded_point`; response expanded from 1 field (`seed`) to 4 fields (`hardened_point`, `server_public_key`, `proof_value_c`, `proof_value_s`)
- Version bumped `2.2.0` → `3.0.0` (major — breaking change for cloud key backup)

## Breaking change

Users who backed up their private key under the old Pythia-derived key (v2.x and earlier) cannot restore it with v3.0.0. They must create a new backup after upgrading. The OPRF protocol prevents offline brute-force attacks on stolen Keyknox backups.

## Pre-requisites (all deployed)

- `virgil-services-brainkey v1.3.1` — DLEQ v3 (`Prove`/`Verify`) live in production
- `virgil-services-api-gateway v2.1.0` — `POST /brainkey/*` proxied to brainkey service

## Test plan

- [ ] Run backup/restore integration tests against production brainkey endpoint
- [ ] Verify `EThreeBackupTest` passes end-to-end
- [ ] Verify wrong-password path throws correct exception